### PR TITLE
Fix quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ You can install the `fsrs` Java library from [Maven Central](https://central.son
 ## Quickstart
 
 ```java
+import io.github.openspacedrepetition.Scheduler;
+import io.github.openspacedrepetition.Card;
+import io.github.openspacedrepetition.Rating;
+import io.github.openspacedrepetition.CardAndReviewLog;
+import io.github.openspacedrepetition.ReviewLog;
+
+import java.time.Instant;
+import java.time.Duration;
+
 public class SRS {
 
     public static void main(String[] args) {

--- a/README.md
+++ b/README.md
@@ -37,6 +37,42 @@ You can install the `fsrs` Java library from [Maven Central](https://central.son
 ## Quickstart
 
 ```java
+public class SRS {
+
+    public static void main(String[] args) {
+
+        Scheduler scheduler = Scheduler.defaultScheduler();
+
+        // note: all new cards are 'due' immediately upon creation
+        Card card = new Card();
+
+        // Choose a rating and review the card with the scheduler
+        /*
+        * Rating.AGAIN (==1) forgot the card
+        * Rating.HARD (==2) remembered the card with serious difficulty
+        * Rating.GOOD (==3) remembered the card after a hesitation
+        * Rating.EASY (==4) remembered the card easily
+        */
+        Rating rating = Rating.GOOD;
+
+        CardAndReviewLog result = scheduler.reviewCard(card, rating);
+        card = result.card();
+
+        // when the card is due next for review
+        Instant due = card.getDue();
+
+        // how much time between now and when the card is due
+        Duration timeDelta = Duration.between(Instant.now(), due);
+
+        System.out.println("Card due on: " + due);
+        System.out.println("Card due in " + timeDelta.toSeconds() + " seconds");
+        // > Card due on: 2025-07-09T04:19:16.535922Z
+        // > Card due in 599 seconds
+
+    }
+
+}
+
 Scheduler scheduler = Scheduler.defaultScheduler();
 
 // note: all new cards are 'due' immediately upon creation


### PR DESCRIPTION
The previous quickstart code snippet lacked the required java boilerplate and import statements to work. This PR fixes that.