### PR TITLE
Add getter methods to Reviewlog class

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,32 +85,4 @@ public class SRS {
     }
 
 }
-
-Scheduler scheduler = Scheduler.defaultScheduler();
-
-// note: all new cards are 'due' immediately upon creation
-Card card = new Card();
-
-// Choose a rating and review the card with the scheduler
-/*
-    * Rating.AGAIN (==1) forgot the card
-    * Rating.HARD (==2) remembered the card with serious difficulty
-    * Rating.GOOD (==3) remembered the card after a hesitation
-    * Rating.EASY (==4) remembered the card easily
-*/
-Rating rating = Rating.GOOD;
-
-CardAndReviewLog result = scheduler.reviewCard(card, rating);
-card = result.card();
-
-// when the card is due next for review
-Instant due = card.getDue();
-
-// how much time between now and when the card is due
-Duration timeDelta = Duration.between(Instant.now(), due);
-
-System.out.println("Card due on: " + due);
-System.out.println("Card due in " + timeDelta.toSeconds() + " seconds");
-// > Card due on: 2025-07-09T04:19:16.535922Z
-// > Card due in 599 seconds
 ```

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ public class SRS {
 
         CardAndReviewLog result = scheduler.reviewCard(card, rating);
         card = result.card();
+        ReviewLog reviewLog = result.reviewLog();
+
+        System.out.println(
+                "Card rated " + reviewLog.getRating() + " at " + reviewLog.getReviewDateTime());
+        // > Card rated GOOD at 2025-07-10T04:16:19.637219Z
 
         // when the card is due next for review
         Instant due = card.getDue();
@@ -74,7 +79,7 @@ public class SRS {
 
         System.out.println("Card due on: " + due);
         System.out.println("Card due in " + timeDelta.toSeconds() + " seconds");
-        // > Card due on: 2025-07-09T04:19:16.535922Z
+        // > Card due on: 2025-07-10T04:26:19.637219Z
         // > Card due in 599 seconds
 
     }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>io.github.open-spaced-repetition</groupId>
   <artifactId>fsrs</artifactId>
   <packaging>jar</packaging>
-  <version>0.1.1</version>
+  <version>0.1.2</version>
 
   <name>fsrs</name>
   <description>Java library for FSRS Spaced Repetition</description>

--- a/src/main/java/io/github/openspacedrepetition/ReviewLog.java
+++ b/src/main/java/io/github/openspacedrepetition/ReviewLog.java
@@ -17,4 +17,20 @@ public class ReviewLog {
         this.reviewDatetime = reviewDatetime;
         this.reviewDuration = reviewDuration;
     }
+
+    public int getCardId() {
+        return this.cardId;
+    }
+
+    public Rating getRating() {
+        return this.rating;
+    }
+
+    public Instant getReviewDateTime() {
+        return this.reviewDatetime;
+    }
+
+    public Integer getReviewDuration() {
+        return this.reviewDuration;
+    }
 }


### PR DESCRIPTION
I added public getter methods for each of the `ReviewLog` class's variables.

Additionally, I also updated the quickstart example in the README to make use of these getter methods and also bumped the version number from `0.1.1` to `0.1.2`.