### PR TITLE
Convert ReviewLog class to a record

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,7 @@
 - [Contribute](#contribute)
 
 ## Installation
-You can install the `fsrs` Java library from [Maven Central](https://central.sonatype.com/artifact/io.github.open-spaced-repetition/fsrs) using Maven:
-```xml
-<dependency>
-    <groupId>io.github.open-spaced-repetition</groupId>
-    <artifactId>fsrs</artifactId>
-    <version>0.1.2</version>
-</dependency>
-```
+You can install the `fsrs` Java library from [Maven Central](https://central.sonatype.com/artifact/io.github.open-spaced-repetition/fsrs).
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ public class SRS {
         ReviewLog reviewLog = result.reviewLog();
 
         System.out.println(
-                "Card rated " + reviewLog.getRating() + " at " + reviewLog.getReviewDateTime());
+                "Card rated " + reviewLog.rating() + " at " + reviewLog.reviewDateTime());
         // > Card rated GOOD at 2025-07-10T04:16:19.637219Z
 
         // when the card is due next for review

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <groupId>io.github.open-spaced-repetition</groupId>
   <artifactId>fsrs</artifactId>
   <packaging>jar</packaging>
-  <version>0.1.2</version>
+  <version>0.2.0</version>
 
   <name>fsrs</name>
   <description>Java library for FSRS Spaced Repetition</description>

--- a/src/main/java/io/github/openspacedrepetition/ReviewLog.java
+++ b/src/main/java/io/github/openspacedrepetition/ReviewLog.java
@@ -3,4 +3,5 @@ package io.github.openspacedrepetition;
 
 import java.time.Instant;
 
-public record ReviewLog(int cardId, Rating rating, Instant reviewDatetime, Integer reviewDuration) {}
+public record ReviewLog(
+        int cardId, Rating rating, Instant reviewDatetime, Integer reviewDuration) {}

--- a/src/main/java/io/github/openspacedrepetition/ReviewLog.java
+++ b/src/main/java/io/github/openspacedrepetition/ReviewLog.java
@@ -3,34 +3,4 @@ package io.github.openspacedrepetition;
 
 import java.time.Instant;
 
-public class ReviewLog {
-
-    private int cardId;
-    private Rating rating;
-    private Instant reviewDatetime;
-    private Integer reviewDuration;
-
-    public ReviewLog(int cardId, Rating rating, Instant reviewDatetime, Integer reviewDuration) {
-
-        this.cardId = cardId;
-        this.rating = rating;
-        this.reviewDatetime = reviewDatetime;
-        this.reviewDuration = reviewDuration;
-    }
-
-    public int getCardId() {
-        return this.cardId;
-    }
-
-    public Rating getRating() {
-        return this.rating;
-    }
-
-    public Instant getReviewDateTime() {
-        return this.reviewDatetime;
-    }
-
-    public Integer getReviewDuration() {
-        return this.reviewDuration;
-    }
-}
+public record ReviewLog(int cardId, Rating rating, Instant reviewDatetime, Integer reviewDuration) {}


### PR DESCRIPTION
The `ReviewLog` class is primarily used to hold data and its variables should be final with no complex behavior. Therefore, it's better for `ReviewLog` to be a record rather than a class.

Also, I bumped the minor version since this will be a breaking change.