### PR TITLE
Convert Scheduler class to use builder pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ public class SRS {
 
     public static void main(String[] args) {
 
-        Scheduler scheduler = new Scheduler();
+        Scheduler scheduler = Scheduler.builder().build();
 
         // note: all new cards are 'due' immediately upon creation
         Card card = Card.builder().build();
@@ -64,7 +64,7 @@ public class SRS {
         ReviewLog reviewLog = result.reviewLog();
 
         System.out.println(
-                "Card rated " + reviewLog.rating() + " at " + reviewLog.reviewDateTime());
+                "Card rated " + reviewLog.rating() + " at " + reviewLog.reviewDatetime());
         // > Card rated GOOD at 2025-07-10T04:16:19.637219Z
 
         // when the card is due next for review

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'io.github.open-spaced-repetition'
-version = '0.4.0'
+version = '0.5.0'
 description = 'Java library for FSRS Spaced Repetition'
 java.sourceCompatibility = JavaVersion.VERSION_17
 java.targetCompatibility = JavaVersion.VERSION_17

--- a/src/main/java/io/github/openspacedrepetition/Scheduler.java
+++ b/src/main/java/io/github/openspacedrepetition/Scheduler.java
@@ -60,6 +60,10 @@ public class Scheduler {
         this.FACTOR = Math.pow(0.9, 1.0 / this.DECAY) - 1;
     }
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     public Scheduler(Scheduler otherScheduler) {
 
         this.parameters = otherScheduler.parameters;

--- a/src/main/java/io/github/openspacedrepetition/Scheduler.java
+++ b/src/main/java/io/github/openspacedrepetition/Scheduler.java
@@ -14,6 +14,7 @@ import lombok.ToString;
 @EqualsAndHashCode
 public class Scheduler {
 
+    // constants
     private static final double[] DEFAULT_PARAMETERS = {
         0.2172, 1.1771, 3.2602, 16.1507, 7.0114, 0.57, 2.0966, 0.0069, 1.5261, 0.112, 1.0178, 1.849,
         0.1133, 0.3127, 2.2934, 0.2191, 3.0004, 0.7536, 0.3332, 0.1437, 0.2
@@ -34,6 +35,7 @@ public class Scheduler {
         new FuzzRange(20.0, Double.POSITIVE_INFINITY, 0.05),
     };
 
+    // instance variables
     private final double[] parameters;
     private final double desiredRetention;
     private final Duration[] learningSteps;
@@ -69,20 +71,6 @@ public class Scheduler {
         this.randomSeed = otherScheduler.randomSeed;
         this.DECAY = otherScheduler.DECAY;
         this.FACTOR = otherScheduler.FACTOR;
-    }
-
-    public Scheduler() {
-
-        this.parameters = DEFAULT_PARAMETERS;
-        this.desiredRetention = 0.9;
-        this.learningSteps = DEFAULT_LEARNING_STEPS;
-        this.relearningSteps = DEFAULT_RELEARNING_STEPS;
-        this.maximumInterval = 36500;
-        this.enableFuzzing = true;
-        this.randomSeed = new Random(42);
-
-        this.DECAY = -this.parameters[20];
-        this.FACTOR = Math.pow(0.9, 1.0 / this.DECAY) - 1;
     }
 
     public static class Builder {

--- a/src/main/java/io/github/openspacedrepetition/Scheduler.java
+++ b/src/main/java/io/github/openspacedrepetition/Scheduler.java
@@ -7,7 +7,9 @@ import java.time.temporal.ChronoUnit;
 import java.util.Random;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+import lombok.experimental.Accessors;
 
 @Getter
 @ToString
@@ -64,6 +66,8 @@ public class Scheduler {
         return new Builder();
     }
 
+    @Setter
+    @Accessors(fluent = true, chain = true)
     public static class Builder {
 
         private double[] parameters = DEFAULT_PARAMETERS;
@@ -76,36 +80,6 @@ public class Scheduler {
 
         public Builder parameters(double[] parameters) {
             this.parameters = parameters;
-            return this;
-        }
-
-        public Builder desiredRetention(double desiredRetention) {
-            this.desiredRetention = desiredRetention;
-            return this;
-        }
-
-        public Builder learningSteps(Duration[] learningSteps) {
-            this.learningSteps = learningSteps;
-            return this;
-        }
-
-        public Builder relearningSteps(Duration[] relearningSteps) {
-            this.relearningSteps = relearningSteps;
-            return this;
-        }
-
-        public Builder maximumInterval(int maximumInterval) {
-            this.maximumInterval = maximumInterval;
-            return this;
-        }
-
-        public Builder enableFuzzing(boolean enableFuzzing) {
-            this.enableFuzzing = enableFuzzing;
-            return this;
-        }
-
-        public Builder randomSeed(Random randomSeed) {
-            this.randomSeed = randomSeed;
             return this;
         }
 

--- a/src/main/java/io/github/openspacedrepetition/Scheduler.java
+++ b/src/main/java/io/github/openspacedrepetition/Scheduler.java
@@ -64,19 +64,6 @@ public class Scheduler {
         return new Builder();
     }
 
-    public Scheduler(Scheduler otherScheduler) {
-
-        this.parameters = otherScheduler.parameters;
-        this.desiredRetention = otherScheduler.desiredRetention;
-        this.learningSteps = otherScheduler.learningSteps;
-        this.relearningSteps = otherScheduler.relearningSteps;
-        this.maximumInterval = otherScheduler.maximumInterval;
-        this.enableFuzzing = otherScheduler.enableFuzzing;
-        this.randomSeed = otherScheduler.randomSeed;
-        this.DECAY = otherScheduler.DECAY;
-        this.FACTOR = otherScheduler.FACTOR;
-    }
-
     public static class Builder {
 
         private double[] parameters = DEFAULT_PARAMETERS;
@@ -125,6 +112,19 @@ public class Scheduler {
         public Scheduler build() {
             return new Scheduler(this);
         }
+    }
+
+    public Scheduler(Scheduler otherScheduler) {
+
+        this.parameters = otherScheduler.parameters;
+        this.desiredRetention = otherScheduler.desiredRetention;
+        this.learningSteps = otherScheduler.learningSteps;
+        this.relearningSteps = otherScheduler.relearningSteps;
+        this.maximumInterval = otherScheduler.maximumInterval;
+        this.enableFuzzing = otherScheduler.enableFuzzing;
+        this.randomSeed = otherScheduler.randomSeed;
+        this.DECAY = otherScheduler.DECAY;
+        this.FACTOR = otherScheduler.FACTOR;
     }
 
     public double getCardRetrievability(Card card, Instant currentDatetime) {

--- a/src/main/java/io/github/openspacedrepetition/Scheduler.java
+++ b/src/main/java/io/github/openspacedrepetition/Scheduler.java
@@ -74,37 +74,37 @@ public class Scheduler {
         private boolean enableFuzzing = true;
         private Random randomSeed = new Random(42);
 
-        public Builder setParameters(double[] parameters) {
+        public Builder parameters(double[] parameters) {
             this.parameters = parameters;
             return this;
         }
 
-        public Builder setDesiredRetention(double desiredRetention) {
+        public Builder desiredRetention(double desiredRetention) {
             this.desiredRetention = desiredRetention;
             return this;
         }
 
-        public Builder setLearningSteps(Duration[] learningSteps) {
+        public Builder learningSteps(Duration[] learningSteps) {
             this.learningSteps = learningSteps;
             return this;
         }
 
-        public Builder setRelearningSteps(Duration[] relearningSteps) {
+        public Builder relearningSteps(Duration[] relearningSteps) {
             this.relearningSteps = relearningSteps;
             return this;
         }
 
-        public Builder setMaximumInterval(int maximumInterval) {
+        public Builder maximumInterval(int maximumInterval) {
             this.maximumInterval = maximumInterval;
             return this;
         }
 
-        public Builder setEnableFuzzing(boolean enableFuzzing) {
+        public Builder enableFuzzing(boolean enableFuzzing) {
             this.enableFuzzing = enableFuzzing;
             return this;
         }
 
-        public Builder setRandomSeed(Random randomSeed) {
+        public Builder randomSeed(Random randomSeed) {
             this.randomSeed = randomSeed;
             return this;
         }

--- a/src/main/java/io/github/openspacedrepetition/Scheduler.java
+++ b/src/main/java/io/github/openspacedrepetition/Scheduler.java
@@ -21,10 +21,14 @@ public class Scheduler {
         0.2172, 1.1771, 3.2602, 16.1507, 7.0114, 0.57, 2.0966, 0.0069, 1.5261, 0.112, 1.0178, 1.849,
         0.1133, 0.3127, 2.2934, 0.2191, 3.0004, 0.7536, 0.3332, 0.1437, 0.2
     };
+    private static final double DEFUALT_DESIRED_RETENTION = 0.9;
     private static final Duration[] DEFAULT_LEARNING_STEPS = {
         Duration.ofMinutes(1), Duration.ofMinutes(10)
     };
     private static final Duration[] DEFAULT_RELEARNING_STEPS = {Duration.ofMinutes(10)};
+    private static final int DEFAULT_MAXIMUM_INTERVAL = 36500;
+    private static final boolean DEFAULT_ENABLE_FUZZING = true;
+    private static final Random DEFAULT_RANDOM_SEED = new Random(42);
     private static final double STABILITY_MIN = 0.001;
     private static final double MIN_DIFFICULTY = 1.0;
     private static final double MAX_DIFFICULTY = 10.0;
@@ -37,7 +41,7 @@ public class Scheduler {
         new FuzzRange(20.0, Double.POSITIVE_INFINITY, 0.05),
     };
 
-    // instance variables
+    // configurable instance variables
     private final double[] parameters;
     private final double desiredRetention;
     private final Duration[] learningSteps;
@@ -45,6 +49,8 @@ public class Scheduler {
     private final int maximumInterval;
     private final boolean enableFuzzing;
     private final Random randomSeed;
+
+    // derived instance variables
     private final double DECAY;
     private final double FACTOR;
 
@@ -71,12 +77,12 @@ public class Scheduler {
     public static class Builder {
 
         private double[] parameters = DEFAULT_PARAMETERS;
-        private double desiredRetention = 0.9;
+        private double desiredRetention = DEFUALT_DESIRED_RETENTION;
         private Duration[] learningSteps = DEFAULT_LEARNING_STEPS;
         private Duration[] relearningSteps = DEFAULT_RELEARNING_STEPS;
-        private int maximumInterval = 36500;
-        private boolean enableFuzzing = true;
-        private Random randomSeed = new Random(42);
+        private int maximumInterval = DEFAULT_MAXIMUM_INTERVAL;
+        private boolean enableFuzzing = DEFAULT_ENABLE_FUZZING;
+        private Random randomSeed = DEFAULT_RANDOM_SEED;
 
         public Builder parameters(double[] parameters) {
             this.parameters = parameters;

--- a/src/test/java/io/github/openspacedrepetition/FSRSTest.java
+++ b/src/test/java/io/github/openspacedrepetition/FSRSTest.java
@@ -17,7 +17,7 @@ public class FSRSTest {
     @Test
     public void testReviewDefaultArg() {
 
-        Scheduler scheduler = new Scheduler();
+        Scheduler scheduler = Scheduler.builder().build();
 
         Card card = Card.builder().build();
 
@@ -39,7 +39,7 @@ public class FSRSTest {
 
         int maximumInterval = 100;
 
-        Scheduler scheduler = new Scheduler.Builder().setMaximumInterval(maximumInterval).build();
+        Scheduler scheduler = Scheduler.builder().setMaximumInterval(maximumInterval).build();
 
         Card card = new Card.Builder().build();
 
@@ -68,7 +68,7 @@ public class FSRSTest {
     @Test
     public void testReviewCard() {
 
-        Scheduler scheduler = new Scheduler.Builder().setEnableFuzzing(false).build();
+        Scheduler scheduler = Scheduler.builder().setEnableFuzzing(false).build();
 
         Rating[] ratings = {
             Rating.GOOD,
@@ -108,7 +108,7 @@ public class FSRSTest {
 
         Random randomSeed1 = new Random(42);
 
-        Scheduler scheduler = new Scheduler.Builder().setRandomSeed(randomSeed1).build();
+        Scheduler scheduler = Scheduler.builder().setRandomSeed(randomSeed1).build();
 
         Card card = Card.builder().build();
 
@@ -127,7 +127,7 @@ public class FSRSTest {
 
         Random randomSeed2 = new Random(12345);
 
-        scheduler = new Scheduler.Builder().setRandomSeed(randomSeed2).build();
+        scheduler = Scheduler.builder().setRandomSeed(randomSeed2).build();
 
         card = Card.builder().build();
 
@@ -148,8 +148,8 @@ public class FSRSTest {
     @Test
     public void testEqualsMethods() {
 
-        Scheduler scheduler1 = new Scheduler();
-        Scheduler scheduler2 = new Scheduler.Builder().setDesiredRetention(0.91).build();
+        Scheduler scheduler1 = Scheduler.builder().build();
+        Scheduler scheduler2 = Scheduler.builder().setDesiredRetention(0.91).build();
         Scheduler scheduler1Copy = new Scheduler(scheduler1);
 
         assertThat(scheduler1).isNotEqualTo(scheduler2);

--- a/src/test/java/io/github/openspacedrepetition/FSRSTest.java
+++ b/src/test/java/io/github/openspacedrepetition/FSRSTest.java
@@ -39,7 +39,7 @@ public class FSRSTest {
 
         int maximumInterval = 100;
 
-        Scheduler scheduler = Scheduler.builder().setMaximumInterval(maximumInterval).build();
+        Scheduler scheduler = Scheduler.builder().maximumInterval(maximumInterval).build();
 
         Card card = new Card.Builder().build();
 
@@ -68,7 +68,7 @@ public class FSRSTest {
     @Test
     public void testReviewCard() {
 
-        Scheduler scheduler = Scheduler.builder().setEnableFuzzing(false).build();
+        Scheduler scheduler = Scheduler.builder().enableFuzzing(false).build();
 
         Rating[] ratings = {
             Rating.GOOD,
@@ -108,7 +108,7 @@ public class FSRSTest {
 
         Random randomSeed1 = new Random(42);
 
-        Scheduler scheduler = Scheduler.builder().setRandomSeed(randomSeed1).build();
+        Scheduler scheduler = Scheduler.builder().randomSeed(randomSeed1).build();
 
         Card card = Card.builder().build();
 
@@ -127,7 +127,7 @@ public class FSRSTest {
 
         Random randomSeed2 = new Random(12345);
 
-        scheduler = Scheduler.builder().setRandomSeed(randomSeed2).build();
+        scheduler = Scheduler.builder().randomSeed(randomSeed2).build();
 
         card = Card.builder().build();
 
@@ -149,7 +149,7 @@ public class FSRSTest {
     public void testEqualsMethods() {
 
         Scheduler scheduler1 = Scheduler.builder().build();
-        Scheduler scheduler2 = Scheduler.builder().setDesiredRetention(0.91).build();
+        Scheduler scheduler2 = Scheduler.builder().desiredRetention(0.91).build();
         Scheduler scheduler1Copy = new Scheduler(scheduler1);
 
         assertThat(scheduler1).isNotEqualTo(scheduler2);


### PR DESCRIPTION
Note that this is a breaking change as the `Scheduler`'s default constructor was removed so that the class more closely conforms to the builder pattern.