### PR TITLE
Specify version for jackson-datatype-jsr310

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation libs.org.junit.jupiter.junit.jupiter
 
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.15.3'
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.2'
 
 }
 


### PR DESCRIPTION
The validation phase on maven central failed because not specific version was specified for jackson-datatype-jsr310. This PR fixes that.